### PR TITLE
Extract days selector component

### DIFF
--- a/src/api/urls.ts
+++ b/src/api/urls.ts
@@ -43,6 +43,9 @@ export const getGroupsUrl = () => `${SCHEDULE_URL}/api/v1/groups`
 
 export const getGroupsPromoteUrl = () => `${SCHEDULE_URL}/api/v1/groups/promote`
 
+export const getGroupsCancelByDaysUrl = () =>
+  `${SCHEDULE_URL}/api/v1/groups/cancel/days`
+
 export const getTeachersUrl = () => `${SCHEDULE_URL}/api/v1/teachers`
 
 export const getLocationsUrl = () => `${SCHEDULE_URL}/api/v1/locations`

--- a/src/features/classes-schedule/groups/cancel-groups-by-days.ts
+++ b/src/features/classes-schedule/groups/cancel-groups-by-days.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from "@/api/api-fetch.ts"
+import { getGroupsCancelByDaysUrl } from "@/api/urls.ts"
+import { DayOfWeek } from "@/features/classes-schedule/types/classes-types.ts"
+
+export interface GroupsCancelDaysData {
+  even: DayOfWeek[]
+  odd: DayOfWeek[]
+}
+
+export const cancelGroupsByDays = async (data: GroupsCancelDaysData) => {
+  await apiFetch(getGroupsCancelByDaysUrl(), {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  })
+}

--- a/src/features/classes-schedule/groups/hooks/use-cancel-groups-by-days.ts
+++ b/src/features/classes-schedule/groups/hooks/use-cancel-groups-by-days.ts
@@ -1,0 +1,30 @@
+import { ApiMutationOptions, ApiMutationResult, ApiMutationWithParams } from "@/types/api-mutation.ts"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { cancelGroupsByDays, GroupsCancelDaysData } from "../cancel-groups-by-days.ts"
+import { ApiError } from "@/api/api-error.ts"
+import toast from "react-hot-toast"
+
+const groupKey = "group"
+
+export const useCancelGroupsByDays: ApiMutationWithParams<GroupsCancelDaysData> = <TContext = unknown>(
+  params: GroupsCancelDaysData,
+  options?: ApiMutationOptions<void, void, TContext>,
+): ApiMutationResult<void, void, TContext> => {
+  const queryClient = useQueryClient()
+
+  return useMutation<void, ApiError, void, TContext>({
+    mutationFn: async () => {
+      await cancelGroupsByDays(params)
+    },
+    onSuccess: (...args) => {
+      toast.success("Пары успешно отменены")
+      void queryClient.invalidateQueries({ queryKey: [groupKey] })
+      options?.onSuccess?.(...args)
+    },
+    onError: (err, _vars, context) => {
+      toast.error("Не удалось отменить пары")
+      options?.onError?.(err, _vars, context)
+    },
+    ...options,
+  })
+}

--- a/src/ui/components/GroupSettings/DaysSelector.tsx
+++ b/src/ui/components/GroupSettings/DaysSelector.tsx
@@ -1,0 +1,114 @@
+import { FC, useEffect, useState } from "react"
+import { ScrollArea } from "@/ui/basic/scroll-area"
+import EvenWeek from "@assets/even-week.svg?react"
+import OddWeek from "@assets/odd-week.svg?react"
+import FirstGroup from "@assets/first-group.svg?react"
+import SecondGroup from "@assets/second-group.svg?react"
+import { WeekModel, DayOfWeek } from "@/features/classes-schedule/types/classes-types.ts"
+import { DayCard } from "./DayCard.tsx"
+import { WeekDayCard } from "./WeekDayCard.tsx"
+
+export interface GlobalDaysResult {
+  even: DayOfWeek[]
+  odd: DayOfWeek[]
+}
+
+export interface DaysSelectorProps {
+  mode: "group" | "global"
+  weeks?: WeekModel[]
+  onGroupChange?: (ids: string[]) => void
+  onGlobalChange?: (result: GlobalDaysResult) => void
+}
+
+const weekDays: DayOfWeek[] = [
+  DayOfWeek.Monday,
+  DayOfWeek.Tuesday,
+  DayOfWeek.Wednesday,
+  DayOfWeek.Thursday,
+  DayOfWeek.Friday,
+  DayOfWeek.Saturday,
+]
+
+export const DaysSelector: FC<DaysSelectorProps> = ({
+  mode,
+  weeks,
+  onGroupChange,
+  onGlobalChange,
+}) => {
+  const [idList, setIdList] = useState<string[]>([])
+  const [evenDays, setEvenDays] = useState<DayOfWeek[]>([])
+  const [oddDays, setOddDays] = useState<DayOfWeek[]>([])
+
+  useEffect(() => {
+    if (mode === "group") {
+      onGroupChange?.(idList)
+    } else {
+      onGlobalChange?.({ even: evenDays, odd: oddDays })
+    }
+  }, [idList, evenDays, oddDays, mode, onGroupChange, onGlobalChange])
+
+  if (mode === "group") {
+    return (
+      <ScrollArea className="flex-grow w-full overflow-hidden">
+        <div className="flex flex-col gap-3 pr-4">
+          {weeks?.map(week => (
+            <div key={week.id} className="flex flex-col gap-2">
+              <div className="flex flex-row gap-2">
+                <span className="font-raleway text-sm">
+                  {week.type == "even" ? "Четная неделя" : "Нечетная неделя"}
+                  {week.subgroup === "first"
+                    ? ", первая подгруппа"
+                    : week.subgroup === "second"
+                      ? ", вторая подгруппа"
+                      : null}
+                </span>
+                {week.type == "even" ? (
+                  <EvenWeek width="20px" height="20px" />
+                ) : (
+                  <OddWeek width="20px" height="20px" />
+                )}
+                {week.subgroup === "first" && <FirstGroup width="20px" height="20px" />}
+                {week.subgroup === "second" && <SecondGroup width="20px" height="20px" />}
+              </div>
+
+              <div className="flex flex-row flex-wrap gap-2">
+                {week.days.map(day => (
+                  <DayCard key={day.id} day={day} setIdList={setIdList} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+    )
+  }
+
+  return (
+    <ScrollArea className="flex-grow w-full overflow-hidden">
+      <div className="flex flex-col gap-3 pr-4">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-row gap-2">
+            <span className="font-raleway text-sm">Четная неделя</span>
+            <EvenWeek width="20px" height="20px" />
+          </div>
+          <div className="flex flex-row flex-wrap gap-2">
+            {weekDays.map(day => (
+              <WeekDayCard key={`even-${day}`} day={day} setList={setEvenDays} />
+            ))}
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-row gap-2">
+            <span className="font-raleway text-sm">Нечетная неделя</span>
+            <OddWeek width="20px" height="20px" />
+          </div>
+          <div className="flex flex-row flex-wrap gap-2">
+            {weekDays.map(day => (
+              <WeekDayCard key={`odd-${day}`} day={day} setList={setOddDays} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </ScrollArea>
+  )
+}

--- a/src/ui/components/GroupSettings/WeekDayCard.tsx
+++ b/src/ui/components/GroupSettings/WeekDayCard.tsx
@@ -1,0 +1,33 @@
+import { Card } from "@/ui/basic/card.tsx"
+import { Dispatch, FC, SetStateAction } from "react"
+import { DayOfWeek } from "@/features/classes-schedule/types/classes-types.ts"
+import { getRussianDayName } from "@/utils/formatters.ts"
+import { Check } from "lucide-react"
+import { useToggle } from "@/hooks/use-toggle.ts"
+
+export interface WeekDayCardProps {
+  day: DayOfWeek
+  setList: Dispatch<SetStateAction<DayOfWeek[]>>
+}
+
+export const WeekDayCard: FC<WeekDayCardProps> = ({ day, setList }) => {
+  const [isSelected, toggle] = useToggle(false)
+
+  const handleSelect = () => {
+    toggle()
+    setList(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day],
+    )
+  }
+
+  return (
+    <Card
+      key={day}
+      className="w-55 h-25 cursor-pointer flex flex-row items-center justify-between px-3"
+      onClick={handleSelect}
+    >
+      <div className="font-semibold">{getRussianDayName(day)}</div>
+      {isSelected && <Check className="h-4 w-4" color="#0966BB" />}
+    </Card>
+  )
+}

--- a/src/ui/pages/settings/GroupSettingsPage.tsx
+++ b/src/ui/pages/settings/GroupSettingsPage.tsx
@@ -22,12 +22,7 @@ import {
   useCancelClassesByDays,
   useClearClassesByGroupId,
 } from "@/features/classes-schedule/classes/hooks/use-class-query.ts"
-import FirstGroup from "@assets/first-group.svg?react"
-import SecondGroup from "@assets/second-group.svg?react"
-import EvenWeek from "@assets/even-week.svg?react"
-import OddWeek from "@assets/odd-week.svg?react"
-import { DayCard } from "@components/GroupSettings/DayCard.tsx"
-import { ScrollArea } from "@/ui/basic/scroll-area"
+import { DaysSelector } from "@components/GroupSettings/DaysSelector.tsx"
 import { 
   MessageCircle, 
   Trash2, 
@@ -177,39 +172,7 @@ export const GroupSettingsPage = () => {
                   Выберите дни для отмены
                 </div>
                 <div className="flex flex-col h-[calc(80vh-100px)]">
-                  <ScrollArea className="flex-grow w-full overflow-hidden">
-                    <div className="flex flex-col gap-3 pr-4">
-                      {group?.weeks.map(week => (
-                        <div key={week.id} className="flex flex-col gap-2">
-                          <div className="flex flex-row gap-2">
-                            <span className="font-raleway text-sm">
-                              {week.type == "even" ? "Четная неделя" : "Нечетная неделя"}
-                              {week.subgroup === "first"
-                                ? ", первая подгруппа"
-                                : week.subgroup === "second"
-                                  ? ", вторая подгруппа"
-                                  : null}
-                            </span>
-                            {week.type == "even" ? (
-                              <EvenWeek width="20px" height="20px" />
-                            ) : (
-                              <OddWeek width="20px" height="20px" />
-                            )}
-                            {week.subgroup === "first" && <FirstGroup width="20px" height="20px" />}
-                            {week.subgroup === "second" && (
-                              <SecondGroup width="20px" height="20px" />
-                            )}
-                          </div>
-
-                          <div className="flex flex-row flex-wrap gap-2">
-                            {week.days.map(day => (
-                              <DayCard key={day.id} day={day} setIdList={setIdList} />
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </ScrollArea>
+                  <DaysSelector mode="group" weeks={group?.weeks} onGroupChange={setIdList} />
                   <div className="flex flex-row items-center justify-end gap-2 mt-4 pt-2">
                     <Button onClick={() => setCancelMultipleDialogOpen(false)}>
                       <ArrowLeft className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- move API endpoint to cancel classes by days for all groups
- add tanstack query hook for new cancel call
- create day selector component that supports group and global modes
- update group settings page to use the new selector

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68401b4ec5a48329a20da5581dcc0742